### PR TITLE
ensure that a compatible version of pip is installed

### DIFF
--- a/venv_update.py
+++ b/venv_update.py
@@ -517,6 +517,10 @@ def stage1(venv_path, reqs):
     if not exists(python):
         return 'virtualenv executable not found: %s' % python
 
+    # ensure that a compatible version of pip is installed
+    run(('pip', '--version'))
+    run((python, '-m', 'pip', 'install', 'pip==1.5.6'))
+
     exec_((python, dotpy(__file__), '--stage2', venv_path) + reqs)  # never returns
 
 

--- a/venv_update.py
+++ b/venv_update.py
@@ -519,7 +519,7 @@ def stage1(venv_path, reqs):
 
     # ensure that a compatible version of pip is installed
     run(('pip', '--version'))
-    run((python, '-m', 'pip', 'install', 'pip==1.5.6'))
+    run((python, '-m', 'pip.__main__', 'install', 'pip>=1.5.0,<6.0.0'))
 
     exec_((python, dotpy(__file__), '--stage2', venv_path) + reqs)  # never returns
 


### PR DESCRIPTION
This diff pegs the version to 1.5.6, it seems that 6.0 changed the api and doesn't work, and 1.4 doesn't contain pip._vendor.

fixes #40