### PR TITLE
force wipe previous package when pip detects a conflict

### DIFF
--- a/venv_update.py
+++ b/venv_update.py
@@ -261,7 +261,7 @@ def pip_install(args):
     # A poor man's dependency injection: monkeypatch :(
     InstallCommand.run = install
     try:
-        pip(('install',) + args)
+        pip(('install', '--exists-action=w') + args)
     finally:
         InstallCommand.run = orig_installcommand['run']
 


### PR DESCRIPTION
does something reasonable when `What to do?  (s)witch, (i)gnore, (w)ipe, (b)ackup` comes up.

fixes #45