### PR TITLE
Add OSX testing support for pip-faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ env:
     #   means we start all lints before any tests
     - TOXENV=lint
     - TOXENV=python
+
+os:
+    - linux
+    - osx
+
 python:
     # in order of most-valuable tests first
     - "3.5"


### PR DESCRIPTION
We currently have one cross platform build that could use the benefits of venv_update.  Currently buils on OSX are blocked from using this script, #108.  If adding OSX to the support list is too much for this project that is ok, let me know.