### PR TITLE
curl from https

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -115,10 +115,10 @@ Python library.
 
 .. parsed-literal::
 
- curl `<http://yelp.github.io/venv-update/install.txt>`_ | bash
+ curl `<https://yelp.github.io/venv-update/install.txt>`_ | bash
  git add bin/venv-update
 
-The paranoid should `read the script <http://yelp.github.io/venv-update/install.txt>`_.
+The paranoid should `read the script <https://yelp.github.io/venv-update/install.txt>`_.
 
 
 Usage


### PR DESCRIPTION
Github redirects http to https anyway, but this is more reassuring