### PR TITLE
install script can take a version argument now.

### DIFF
--- a/install.txt
+++ b/install.txt
@@ -4,11 +4,15 @@
 # To run it:
 #   curl http://yelp.github.io/venv-update/install.txt | bash
 #
+# Or, to get a specific version:
+#   curl http://yelp.github.io/venv-update/install.txt | bash -s v1.0.0
+#
 # Documentation:
 #   https://venv-update.rtfd.org
 #######################################################################
 set -Eeu
 trap 'echo "[31mFAILED[m (code $?)"' ERR
+version=${1:-stable}
 
 colorize() {
     echo "[01;36m>[m [01;33m$@[m" >&2
@@ -19,7 +23,8 @@ canhas(){
 }
 download() {
     if canhas curl; then
-        colorize curl "$1" --output "$2"
+        # --fail: stop if we get 404. wget already does this.
+        colorize curl --fail "$1" --output "$2"
     elif canhas wget; then
         colorize wget "$1" --output-document "$2"
     else
@@ -29,7 +34,7 @@ download() {
 }
 
 colorize mkdir -p ./bin
-download https://raw.githubusercontent.com/Yelp/venv-update/stable/venv_update.py ./bin/venv-update
+download https://raw.githubusercontent.com/Yelp/venv-update/$version/venv_update.py ./bin/venv-update
 colorize chmod 755 bin/venv-update
 
 echo '


### PR DESCRIPTION
@abrarsheikh

Testing:

```
$ cat install.txt | bash
> mkdir -p ./bin
> curl --fail https://raw.githubusercontent.com/Yelp/venv-update/stable/venv_update.py --output ./bin/venv-update
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 14687  100 14687    0     0   123k      0 --:--:-- --:--:-- --:--:--  146k
> chmod 755 bin/venv-update

I have just installed `venv-update` to your bin/ directory.

$ cat install.txt | bash -s v1.0.0
> mkdir -p ./bin
> curl --fail https://raw.githubusercontent.com/Yelp/venv-update/v1.0.0/venv_update.py --output ./bin/venv-update
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 14687  100 14687    0     0  79190      0 --:--:-- --:--:-- --:--:--  113k
> chmod 755 bin/venv-update

I have just installed `venv-update` to your bin/ directory.


$ cat install.txt | bash -s v1.0.2
> mkdir -p ./bin
> curl --fail https://raw.githubusercontent.com/Yelp/venv-update/v1.0.2/venv_update.py --output ./bin/venv-update
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
FAILED (code 22)
```