### PR TITLE
Fix infinite loop that would occur when trying to use venv-update with some instance of brew python

### DIFF
--- a/venv_update.py
+++ b/venv_update.py
@@ -205,7 +205,10 @@ def exec_scratch_virtualenv(args):
         rename(tmp, scratch.src)
 
     import sys
-    if sys.prefix != scratch.venv:
+    from os.path import realpath
+    # We want to compare the paths themselves as sometimes sys.path is the same
+    # as scratch.venv, but with a suffix of bin/..
+    if realpath(sys.prefix) != realpath(scratch.venv):
         # TODO-TEST: sometimes we would get a stale version of venv-update
         exec_((scratch.python, dotpy(__file__)) + args)  # never returns
 


### PR DESCRIPTION
I was running into an issue where venv-update would go into an infinite loop of
execing itself.  This was because sys.path was the same as scratch.venv, but it
had a suffix of bin/...

To fix this, I made the comparison compare absolute paths instead of strings,
which seems like the semantically correct assertion.