### PR TITLE
Update pip-faster to support newer pip versions

### DIFF
--- a/requirements.d/import_tests.txt
+++ b/requirements.d/import_tests.txt
@@ -7,6 +7,6 @@
 # "tests of (and fixes for) Config.fromdictargs"
 -e git+git://github.com/bukzor/pytest.git@eabf2f9#egg=pytest
 
-pip<2
+pip>=8
 wheel
 six

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ def main():
         py_modules=['venv_update', 'pip_faster'],
         packages=find_packages('.', exclude=('tests*',)),
         install_requires=[
-            'pip>=1.5.5,<6.0.0',  # 1.5.4 causes TypeError: add() got an unexpected keyword argument 'replace'
+            'pip>=8.0.0',
             'wheel>0.25.0',  # 0.25.0 causes get_tag AssertionError in python3
             'setuptools>=0.8.0',  # 0.7 causes "'sys_platform' not defined" when installing wheel >0.25
         ],

--- a/tests/functional/conflict_test.py
+++ b/tests/functional/conflict_test.py
@@ -33,19 +33,15 @@ conflicting_package
 
     err = T.strip_coverage_warnings(err)
     err = T.strip_pip_warnings(err)
-    assert err == ''
-
+    assert err == ('''\
+Error: version conflict: many-versions-package 3 (venv/{python_lib})'''
+''' <-> many-versions-package<2 (from conflicting_package->-r requirements.txt (line 3))
+''').format(python_lib=PYTHON_LIB)
     out = T.uncolor(out)
-    assert (
-        '''
-Cleaning up...
-Error: version conflict: many-versions-package 3 (venv/%s)'''
-        ''' <-> many-versions-package<2 (from conflicting-package->-r requirements.txt (line 3))
-Storing debug log for failure in %s/home/.pip/pip.log
+    assert out.endswith('''
 
 Something went wrong! Sending 'venv' back in time, so make knows it's invalid.
-''' % (PYTHON_LIB, tmpdir)
-    ) in out
+''')
 
     assert_venv_marked_invalid(tmpdir.join('venv'))
 
@@ -72,29 +68,26 @@ pure_python_package==0.1.0
     out, err = excinfo.value.result
 
     err = T.strip_coverage_warnings(err)
-    assert err == ''
-
+    assert err == ('''\
+Error: version conflict: pure-python-package 0.1.0 (venv/{python_lib})'''
+        ''' <-> pure-python-package>=0.2.1 (from dependant_package->-r requirements.txt (line 2))
+Error: version conflict: many-versions-package 3 (venv/{python_lib})'''
+        ''' <-> many-versions-package<2 (from conflicting_package->-r requirements.txt (line 3))
+''').format(python_lib=PYTHON_LIB)
     out = T.uncolor(out)
-    assert (
+    assert out.endswith(
         '''
-Cleaning up...
-Error: unmet dependency: implicit-dependency (from dependant-package->-r requirements.txt (line 2))
-Error: version conflict: many-versions-package 1 (venv/%s)'''
-        ''' <-> many-versions-package>=2,<4 (from dependant-package->-r requirements.txt (line 2))
-Error: version conflict: pure-python-package 0.1.0 (venv/%s)'''
-        ''' <-> pure-python-package>=0.2.1 (from dependant-package->-r requirements.txt (line 2))
-Storing debug log for failure in %s/home/.pip/pip.log
 
 Something went wrong! Sending 'venv' back in time, so make knows it's invalid.
-''' % (PYTHON_LIB, PYTHON_LIB, tmpdir)
-    ) in out
+''')
 
     assert_venv_marked_invalid(tmpdir.join('venv'))
 
 
 @pytest.mark.usefixtures('pypi_server')
 def test_editable_egg_conflict(tmpdir):
-    conflicting_package = tmpdir / 'tmp/conflicting_package'
+    tmp_conflicting_package = 'tmp/conflicting_package'
+    conflicting_package = tmpdir / tmp_conflicting_package
     many_versions_package_2 = tmpdir / 'tmp/many_versions_package_2'
 
     from shutil import copytree
@@ -122,28 +115,27 @@ def test_editable_egg_conflict(tmpdir):
 
         err = T.strip_coverage_warnings(err)
         err = T.strip_pip_warnings(err)
-        assert err == ''
-
-        out = T.uncolor(out)
-        expected = '\nSuccessfully installed many-versions-package conflicting-package\n'
-        assert expected in out
-        rest = out.rsplit(expected, 1)[-1]
-
         if True:  # :pragma:nocover:pylint:disable=using-constant-test
             # Debian de-vendorizes the version of pip it ships
             try:
                 from sysconfig import get_python_version
             except ImportError:  # <= python2.6
                 from distutils.sysconfig import get_python_version
+        assert err == ('''\
+Error: version conflict: many-versions-package 2 ({0}/many_versions_package-2-py{1}.egg)'''
+''' <-> many_versions_package<2 (from conflicting-package==1->-r requirements.txt (line 1))
+''').format(tmp_conflicting_package, get_python_version())
+
+        out = T.uncolor(out)
+        expected = '\nSuccessfully installed conflicting-package many-versions-package-1\n'
+        assert expected in out
+        rest = out.rsplit(expected, 1)[-1]
+
         assert (
             '''\
-Cleaning up...
-Error: version conflict: many-versions-package 2 (tmp/conflicting_package/many_versions_package-2-py{0}.egg)'''
-            ''' <-> many-versions-package<2 (from conflicting-package==1->-r requirements.txt (line 1))
-Storing debug log for failure in {1}/home/.pip/pip.log
 
 Something went wrong! Sending 'venv' back in time, so make knows it's invalid.
-'''.format(get_python_version(), tmpdir)
+'''
         ) == rest
 
         assert_venv_marked_invalid(tmpdir.join('venv'))

--- a/tests/functional/faster.py
+++ b/tests/functional/faster.py
@@ -7,6 +7,7 @@ import pytest
 
 from testing import enable_coverage
 from testing import install_coverage
+from testing import maybe_add_wheel
 from testing import pip_freeze
 from testing import requirements
 from testing import venv_update
@@ -37,7 +38,9 @@ def time_savings(tmpdir, between):
             PIP_TIMEOUT='0',
         )
         time1 = time() - start
-        expected = '\n'.join((
+
+        frozen_requirements = pip_freeze().split('\n')
+        expected = (
             'dependant-package==1',
             'implicit-dependency==1',
             'many-versions-package==2.1',
@@ -45,10 +48,10 @@ def time_savings(tmpdir, between):
             'pure-python-package==0.2.1',
             'slow-python-package==0.1.0',
             'venv-update==%s' % __version__,
-            'wheel==0.29.0',
-            ''
-        ))
-        assert pip_freeze() == expected
+            '',
+        )
+        expected = maybe_add_wheel(expected)
+        assert set(frozen_requirements) == set(expected)
 
         between()
         install_coverage()
@@ -65,7 +68,7 @@ def time_savings(tmpdir, between):
             ftp_proxy='ftp://127.0.0.1:333333',
         )
         time2 = time() - start
-        assert pip_freeze() == expected
+        assert set(pip_freeze().split('\n')) == set(expected)
 
         print()
         print('%.3fs originally' % time1)

--- a/tests/functional/validation.py
+++ b/tests/functional/validation.py
@@ -161,7 +161,8 @@ def test_update_invalidated_missing_activate(tmpdir):
 
         out, err = venv_update()
         err = strip_pip_warnings(err)
-        assert err == "sh: 1: .: Can't open venv/bin/activate\n"
+        assert 'Can\'t open venv/bin/activate' in err
+        assert 'You must give at least one requirement to install' in err
         out = uncolor(out)
         assert out.startswith('''\
 > virtualenv venv
@@ -186,7 +187,7 @@ def it_gives_the_same_python_version_as_we_started_with(tmpdir):
         out, err = run('./venv/bin/python', 'venv_update.py')
 
         err = strip_pip_warnings(err)
-        assert err == ''
+        assert 'You must give at least one requirement to install' in err
         out = uncolor(out)
         assert out.startswith('''\
 > virtualenv venv

--- a/tests/regression/pip_faster.py
+++ b/tests/regression/pip_faster.py
@@ -38,75 +38,17 @@ def test_circular_dependencies():
         '-vv',  # show debug logging
         'circular-dep-a',
     )
-    assert err == ''
+    assert err == 'Circular dependency! circular-dep-a==1.0 (from circular-dep-b==1.0->circular-dep-a)\n'
     out = uncolor(out)
     assert out.endswith('''
 tracing: circular-dep-a
 already queued: circular-dep-b==1.0 (from circular-dep-a)
 tracing: circular-dep-b==1.0 (from circular-dep-a)
-Circular dependency! circular-dep-a==1.0 (from circular-dep-b==1.0->circular-dep-a)
 ''')
 
     frozen_requirements = pip_freeze(str(venv)).split('\n')
     assert 'circular-dep-a==1.0' in frozen_requirements
     assert 'circular-dep-b==1.0' in frozen_requirements
-
-
-@pytest.mark.usefixtures('pypi_server')
-@pytest.mark.skipif(
-    sys.version_info > (3, 0),
-    reason='ancient versions are not py3 compatible, even for install',
-)
-@pytest.mark.parametrize('reqs', [
-    # old setuptools and old pip
-    ['setuptools==0.6c11', 'pip==1.4.1'],
-    # old setuptools and new pip
-    ['setuptools==0.6c11', 'pip==1.5.6'],
-    # new setuptools and old pip
-    ['setuptools==18.2', 'pip==1.4.1'],
-])
-def test_old_pip_and_setuptools(tmpdir, reqs):
-    """We should be able to use pip-faster's wheel building even if we have
-    ancient pip and setuptools.
-
-    https://github.com/Yelp/venv-update/issues/33
-    """
-    tmpdir.chdir()
-
-    # 1. Create an empty virtualenv.
-    # 2. Install old pip/setuptools that don't support wheel building.
-    # 3. Install pip-faster.
-    # 4. Install pure-python-package and assert it was wheeled during install.
-    tmpdir.join('venv')
-    venv = Path('venv')
-    run('virtualenv', venv.strpath)
-
-    # We need to add public PyPI as an extra URL since we're installing
-    # packages (setuptools and pip) which aren't available from our PyPI fixture.
-    from os import environ
-    environ['PIP_EXTRA_INDEX_URL'] = 'https://pypi.python.org/simple/'
-    try:
-        pip = venv.join('bin/pip').strpath
-        for req in reqs:
-            run(pip, 'install', '--', req)
-        # wheel needs argparse but it won't get installed
-        if sys.version_info < (2, 7):
-            run(pip, 'install', 'argparse')
-        run(pip, 'install', 'venv-update==' + __version__)
-    finally:
-        del environ['PIP_EXTRA_INDEX_URL']
-
-    run(str(venv.join('bin/pip-faster')), 'install', 'pure_python_package')
-
-    # it was installed
-    assert 'pure-python-package==0.2.1' in pip_freeze(str(venv)).split('\n')
-
-    # it was wheeled
-    from pip.wheel import Wheel
-    wheelhouse = tmpdir.join('home', '.cache', 'pip-faster', 'wheelhouse')
-    assert 'pure-python-package' in [
-        Wheel(f.basename).name for f in wheelhouse.listdir()
-    ]
 
 
 @pytest.mark.usefixtures('tmpdir')
@@ -118,10 +60,10 @@ def test_install_whl_over_http(pypi_server):
     assert err == ''
     out = uncolor(out)
     assert out == '''\
-Downloading/unpacking %s/packages/wheeled_package-0.2.0-py2.py3-none-any.whl
-  Downloading wheeled_package-0.2.0-py2.py3-none-any.whl
+Collecting wheeled-package==0.2.0 from {pypi_server}/packages/wheeled_package-0.2.0-py2.py3-none-any.whl
+  Downloading {pypi_server}/packages/wheeled_package-0.2.0-py2.py3-none-any.whl
   Saved ./home/.cache/pip-faster/wheelhouse/wheeled_package-0.2.0-py2.py3-none-any.whl
+Skipping wheeled-package, due to already being wheel.
 Installing collected packages: wheeled-package
-Successfully installed wheeled-package
-Cleaning up...
-''' % pypi_server
+Successfully installed wheeled-package-0.2.0
+'''.format(pypi_server=pypi_server)

--- a/tests/testing/__init__.py
+++ b/tests/testing/__init__.py
@@ -3,9 +3,11 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from distutils.version import LooseVersion
 from re import compile as Regex
 from re import MULTILINE
 
+import pip as pipmodule
 from py._path.local import LocalPath as Path
 
 TOP = Path(__file__) / '../../..'
@@ -136,3 +138,10 @@ class OtherPython(object):
         else:
             self.interpreter = 'python2.7'
             self.version_prefix = '2.7.'
+
+
+def maybe_add_wheel(expected):
+    # wheel is excluded from the pip freeze output since 8.1.0
+    if LooseVersion(pipmodule.__version__) < LooseVersion('8.1.0'):
+        expected.append('wheel==0.29.0')
+    return expected

--- a/tests/unit/simple_test.py
+++ b/tests/unit/simple_test.py
@@ -13,52 +13,6 @@ def test_importable():
     assert venv_update
 
 
-def test_parse_reqs(tmpdir):
-    tmpdir.chdir()
-
-    with open('setup.py', 'w') as setup:
-        setup.write('\n')
-
-    with open('reqs.txt', 'w') as reqs:
-        reqs.write('''\
-.
-
--r reqs2.txt
-# a comment here
-mccabe
-
-pep8==1.0
-
--e hg+https://bitbucket.org/bukzor/coverage.py@__main__-support#egg=aweirdname
--e git+git://github.com/bukzor/cov-core.git@master#egg=cov-core
-hg+https://bitbucket.org/logilab/pylint@58c66aa083777059a2e6b46f6a0545a2f4977097
-
-file:///my/random/project
--e file:///my/random/project2
-''')
-
-    with open('reqs2.txt', 'w') as reqs:
-        reqs.write('''\
-pep8''')
-
-    # show that ordering is preserved in the parse
-    parsed = pip_faster.pip_parse_requirements(('reqs.txt',))
-    assert [
-        (req.name, req.url)
-        for req in parsed
-    ] == [
-        (None, 'file://' + tmpdir.strpath),
-        ('pep8', None),
-        ('mccabe', None),
-        ('pep8', None),
-        ('aweirdname', 'hg+https://bitbucket.org/bukzor/coverage.py@__main__-support#egg=aweirdname'),
-        ('cov-core', 'git+git://github.com/bukzor/cov-core.git@master#egg=cov-core'),
-        (None, 'hg+https://bitbucket.org/logilab/pylint@58c66aa083777059a2e6b46f6a0545a2f4977097'),
-        (None, 'file:///my/random/project'),
-        (None, 'file:///my/random/project2'),
-    ]
-
-
 def test_pip_get_installed():
     installed = pip_faster.pip_get_installed()
     installed = pip_faster.reqnames(installed)


### PR DESCRIPTION
Updated pip_faster.py to support recent versions of pip. Right now that
means pip >= 8.0.0.

The output of the pip command has changed quite a bit lately, so I had
to patch most of the tests. One notable difference is that now some
warnings and errors are going to stderr instead of stdout.

----
@asottile @chriskuehl @bukzor Please have a look at the issues below. I removed these parts but I'm not sure if they were / are useful.

1. `pip_parse_requirements` doesn't seem to be used anywhere apart in its test. Is that useful?
2. `delete_marker_filename` doesn't exist anymore, so I've just removed our override. Should I do anything more?
3. what's the idea behind the lines of code following `from pip.utils import rmtree, unzip_file`? If I keep them pip breaks because setup.py gets deleted by them.
4. `--no-prune` is the default behavior when you don't specify `--prune` so it seems useless. It's also never used in the code.

----
Do we need to support pip<8?