### PR TITLE
Require pip >= 8.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@
         - .:tests
 -   repo: local
     hooks:
-    -   id: system
+    -   id: pylint
         name: PyLint
         entry: python -m pylint.__main__
         language: system

--- a/requirements.d/import_tests.txt
+++ b/requirements.d/import_tests.txt
@@ -7,6 +7,6 @@
 # "tests of (and fixes for) Config.fromdictargs"
 -e git+git://github.com/bukzor/pytest.git@eabf2f9#egg=pytest
 
-pip<2
+pip>8.1
 wheel
 six

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ def main():
         py_modules=['venv_update', 'pip_faster'],
         packages=find_packages('.', exclude=('tests*',)),
         install_requires=[
-            'pip>=1.5.5,<6.0.0',  # 1.5.4 causes TypeError: add() got an unexpected keyword argument 'replace'
+            'pip>=8.1.0',
             'wheel>0.25.0',  # 0.25.0 causes get_tag AssertionError in python3
             'setuptools>=0.8.0',  # 0.7 causes "'sys_platform' not defined" when installing wheel >0.25
         ],

--- a/tests/functional/faster.py
+++ b/tests/functional/faster.py
@@ -3,7 +3,10 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import contextlib
+
 import pytest
+from py._path.local import LocalPath as Path
 
 from testing import enable_coverage
 from testing import install_coverage
@@ -17,55 +20,66 @@ def time_savings(tmpdir, between):
     """install twice, and the second one should be faster, due to whl caching"""
     with tmpdir.as_cwd():
         enable_coverage()
-        install_coverage()
 
-        requirements('\n'.join((
-            'project_with_c',
-            'pure_python_package==0.2.1',
-            'slow_python_package==0.1.0',
-            'dependant_package',
-            'many_versions_package>=2,<3',
-            ''
-        )))
+        @contextlib.contextmanager
+        def venv_setup():
+            # First just set up a blank virtualenv, this'll bypass the
+            # bootstrap when we're actually testing for speed
+            if not Path('venv').exists():
+                requirements('')
+                venv_update()
+            install_coverage()
+
+            # Now the actual requirements we'll install
+            requirements('\n'.join((
+                'project_with_c',
+                'pure_python_package==0.2.1',
+                'slow_python_package==0.1.0',
+                'dependant_package',
+                'many_versions_package>=2,<3',
+                ''
+            )))
+
+            yield
+
+            expected = '\n'.join((
+                'dependant-package==1',
+                'implicit-dependency==1',
+                'many-versions-package==2.1',
+                'project-with-c==0.1.0',
+                'pure-python-package==0.2.1',
+                'slow-python-package==0.1.0',
+                'venv-update==%s' % __version__,
+                ''
+            ))
+            assert pip_freeze() == expected
 
         from time import time
 
-        start = time()
-        venv_update(
-            PIP_VERBOSE='1',
-            PIP_RETRIES='0',
-            PIP_TIMEOUT='0',
-        )
-        time1 = time() - start
-        expected = '\n'.join((
-            'dependant-package==1',
-            'implicit-dependency==1',
-            'many-versions-package==2.1',
-            'project-with-c==0.1.0',
-            'pure-python-package==0.2.1',
-            'slow-python-package==0.1.0',
-            'venv-update==%s' % __version__,
-            'wheel==0.29.0',
-            ''
-        ))
-        assert pip_freeze() == expected
+        with venv_setup():
+            start = time()
+            venv_update(
+                PIP_VERBOSE='1',
+                PIP_RETRIES='0',
+                PIP_TIMEOUT='0',
+            )
+            time1 = time() - start
 
         between()
-        install_coverage()
 
-        start = time()
-        # second install should also need no network access
-        # these are localhost addresses with arbitrary invalid ports
-        venv_update(
-            PIP_VERBOSE='1',
-            PIP_RETRIES='0',
-            PIP_TIMEOUT='0',
-            http_proxy='http://127.0.0.1:111111',
-            https_proxy='https://127.0.0.1:222222',
-            ftp_proxy='ftp://127.0.0.1:333333',
-        )
-        time2 = time() - start
-        assert pip_freeze() == expected
+        with venv_setup():
+            start = time()
+            # second install should also need no network access
+            # these are localhost addresses with arbitrary invalid ports
+            venv_update(
+                PIP_VERBOSE='1',
+                PIP_RETRIES='0',
+                PIP_TIMEOUT='0',
+                http_proxy='http://127.0.0.1:111111',
+                https_proxy='https://127.0.0.1:222222',
+                ftp_proxy='ftp://127.0.0.1:333333',
+            )
+            time2 = time() - start
 
         print()
         print('%.3fs originally' % time1)
@@ -89,32 +103,13 @@ def test_noop_install_faster(tmpdir):
     assert time_savings(tmpdir, between=do_nothing) > 6
 
 
-@pytest.mark.usefixtures('pypi_server_with_fallback')
-def test_cached_clean_install_faster(tmpdir, pypi_packages):
+@pytest.mark.usefixtures('pypi_server_with_fallback', 'pypi_packages')
+def test_cached_clean_install_faster(tmpdir):
     def clean():
         venv = tmpdir.join('venv')
         assert venv.isdir()
         venv.remove()
         assert not venv.exists()
-        enable_coverage()
-
-        # copy the bootstrap-essential wheels to the wheelhouse where they can be found.
-        # FIXME: pip7 has the behavior we want: wheel anything we install
-        from glob import glob
-
-        for package in (
-                'argparse',
-                'pip',
-                'venv_update',
-                'wheel',
-        ):
-            pattern = str(pypi_packages.join(package + '-*.whl'))
-            wheel = glob(pattern)
-            assert len(wheel) == 1, (pattern, wheel)
-            wheel = wheel[0]
-
-            from shutil import copy
-            copy(wheel, str(tmpdir.join('home/.cache/pip-faster/wheelhouse')))
 
     # the slow-python-package takes five seconds to compile
     assert time_savings(tmpdir, between=clean) > 5

--- a/tests/functional/pip_faster.py
+++ b/tests/functional/pip_faster.py
@@ -3,12 +3,13 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import pytest
-from pip.wheel import Wheel
 
+from testing import cached_wheels
 from testing import install_coverage
 from testing import pip_freeze
 from testing import requirements
 from testing import run
+from testing import strip_pip_warnings
 from testing import TOP
 from testing import uncolor
 from venv_update import __version__
@@ -17,12 +18,11 @@ from venv_update import __version__
 def it_shows_help_for_prune():
     out, err = run('pip-faster', 'install', '--help')
     assert '''
-  --no-clean                  Don't clean up build directories.
   --prune                     Uninstall any non-required packages.
   --no-prune                  Do not uninstall any non-required packages.
 
-Package Index Options:
-''' in out
+Package Index Options (including deprecated options):
+''' in out  # noqa
     assert err == ''
 
 
@@ -32,7 +32,7 @@ def it_installs_stuff(tmpdir):
     install_coverage(venv)
 
     assert pip_freeze(str(venv)) == '''\
-coverage==4.3.3
+coverage==4.3.4
 coverage-enable-subprocess==1.0
 '''
 
@@ -42,7 +42,7 @@ coverage-enable-subprocess==1.0
     assert [
         req.split('==')[0]
         for req in pip_freeze(str(venv)).split()
-    ] == ['coverage', 'coverage-enable-subprocess', 'venv-update', 'wheel']
+    ] == ['coverage', 'coverage-enable-subprocess', 'venv-update']
 
     run(str(venv.join('bin/pip-faster')), 'install', 'pure_python_package')
 
@@ -87,18 +87,15 @@ def it_installs_stuff_with_dash_e_without_wheeling(tmpdir):
 
     frozen_requirements = pip_freeze(str(venv)).split('\n')
     assert set(frozen_requirements) == set([
-        '-e git://github.com/Yelp/dumb-init.git@87545be699a13d0fd31f67199b7782ebd446437e#egg=dumb_init-dev',  # noqa
+        '-e git://github.com/Yelp/dumb-init.git@87545be699a13d0fd31f67199b7782ebd446437e#egg=dumb_init',  # noqa
         'coverage-enable-subprocess==1.0',
-        'coverage==4.3.3',
+        'coverage==4.3.4',
         'venv-update==' + __version__,
-        'wheel==0.29.0',
         '',
     ])
 
     # we shouldn't wheel things installed editable
-    wheelhouse = tmpdir.join('home', '.cache', 'pip-faster', 'wheelhouse')
-    assert set(Wheel(f.basename).name for f in wheelhouse.listdir()) == set([
-    ])
+    assert not tuple(cached_wheels(tmpdir))
 
 
 @pytest.mark.usefixtures('pypi_server')
@@ -117,23 +114,21 @@ def it_doesnt_wheel_local_dirs(tmpdir):
 
     frozen_requirements = pip_freeze(str(venv)).split('\n')
     assert set(frozen_requirements) == set([
-        'coverage==4.3.3',
+        'coverage==4.3.4',
         'coverage-enable-subprocess==1.0',
         'dependant-package==1',
         'implicit-dependency==1',
         'many-versions-package==3',
         'pure-python-package==0.2.1',
         'venv-update==' + __version__,
-        'wheel==0.29.0',
         '',
     ])
 
-    wheelhouse = tmpdir.join('home', '.cache', 'pip-faster', 'wheelhouse')
-    assert set(Wheel(f.basename).name for f in wheelhouse.listdir()) == set([
+    assert set(wheel.name for wheel in cached_wheels(tmpdir)) == set((
         'implicit-dependency',
         'many-versions-package',
         'pure-python-package',
-    ])
+    ))
 
 
 @pytest.mark.usefixtures('pypi_server')
@@ -153,15 +148,13 @@ def it_doesnt_wheel_git_repos(tmpdir):
     frozen_requirements = pip_freeze(str(venv)).split('\n')
     assert set(frozen_requirements) == set([
         'coverage-enable-subprocess==1.0',
-        'coverage==4.3.3',
+        'coverage==4.3.4',
         'dumb-init==0.5.0',
         'venv-update==' + __version__,
-        'wheel==0.29.0',
         '',
     ])
 
-    wheelhouse = tmpdir.join('home', '.cache', 'pip-faster', 'wheelhouse')
-    assert set(Wheel(f.basename).name for f in wheelhouse.listdir()) == set()
+    assert not tuple(cached_wheels(tmpdir))
 
 
 @pytest.mark.usefixtures('pypi_server')
@@ -189,10 +182,9 @@ def it_gives_proper_error_without_requirements(tmpdir):
     pip = venv.join('bin/pip').strpath
     run(pip, 'install', 'venv-update==' + __version__)
 
-    out, err = run(str(venv.join('bin/pip-faster')), 'install')
-    out = uncolor(out)
-    assert out.startswith('You must give at least one requirement to install')
-    assert err == ''
+    _, err = run(str(venv.join('bin/pip-faster')), 'install')
+    err = strip_pip_warnings(err)
+    assert err.startswith('You must give at least one requirement to install')
 
 
 @pytest.mark.usefixtures('pypi_server')
@@ -210,11 +202,24 @@ def it_can_handle_a_bad_findlink(tmpdir):
         'pure-python-package',
     )
     out = uncolor(out)
+    err = strip_pip_warnings(err)
 
-    assert '''
-Candidate wheel: pure_python_package-0.2.1-py2.py3-none-any.whl
+    expected = '''\
+Successfully built pure-python-package
 Installing collected packages: pure-python-package
-Successfully installed pure-python-package
-''' in out
-    assert err == ''
+'''
+    assert expected in out
+    # Between this there's:
+    # 'changing mode of .../venv/bin/pure-python-script to 775'
+    # but that depends on umask
+    _, rest = out.split(expected)
+    expected2 = '''\
+Successfully installed pure-python-package-0.2.1
+Cleaning up...
+'''
+    assert expected2 in rest
+    assert err == (
+        "  Url 'git+wat://not/a/thing' is ignored. "
+        'It is either a non-existing path or lacks a specific scheme.\n'
+    )
     assert 'pure-python-package==0.2.1' in pip_freeze(str(venv)).split('\n')

--- a/tests/functional/relocation_test.py
+++ b/tests/functional/relocation_test.py
@@ -31,7 +31,6 @@ def test_relocatable_cache(tmpdir, pypi_server):
     venv_update()
     path_rest = (
         '.cache', 'pip-faster', 'wheelhouse', pypi_server, 'simple',
-        'pure-python-package',
         'pure_python_package-0.2.1-py2.py3-none-any.whl',
     )
     assert tmpdir.join('home', *path_rest).exists()

--- a/tests/functional/relocation_test.py
+++ b/tests/functional/relocation_test.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 import pytest
 
+from testing import install_coverage
 from testing import Path
 from testing import requirements
 from testing import run
@@ -21,3 +22,34 @@ def test_relocatable(tmpdir):
     python = 'relocated/bin/python'
     assert Path(python).exists()
     run(python, '-m', 'pip.__main__', '--version')
+
+
+@pytest.mark.usefixtures('pypi_packages')
+def test_relocatable_cache(tmpdir, pypi_server):
+    tmpdir.chdir()
+    requirements('pure-python-package==0.2.1')
+    venv_update()
+    path_rest = (
+        '.cache', 'pip-faster', 'wheelhouse', pypi_server, 'simple',
+        'pure-python-package',
+        'pure_python_package-0.2.1-py2.py3-none-any.whl',
+    )
+    assert tmpdir.join('home', *path_rest).exists()
+    tmpdir.join('home').rename('home2')
+    assert tmpdir.join('home2', *path_rest).exists()
+
+
+@pytest.mark.usefixtures('pypi_server', 'pypi_packages')
+def test_pip_cache_goes_missing_still_installable(tmpdir):
+    tmpdir.chdir()
+    requirements('pure-python-package==0.2.1')
+    venv_update()
+    tmpdir.join('venv').remove()
+
+    # This breaks the symlinks in our cache
+    pip_cache = tmpdir.join('home', '.cache', 'pip')
+    assert pip_cache.exists()
+    pip_cache.remove()
+
+    install_coverage()
+    venv_update()

--- a/tests/functional/simple_test.py
+++ b/tests/functional/simple_test.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from subprocess import CalledProcessError
 from sys import version_info
 
 import pytest
@@ -45,7 +46,6 @@ def test_install_custom_path_and_requirements(tmpdir):
     assert pip_freeze('venv2') == '\n'.join((
         'six==1.8.0',
         'venv-update==' + __version__,
-        'wheel==0.29.0',
         ''
     ))
 
@@ -98,7 +98,37 @@ def test_eggless_url(tmpdir):
     requirements('-e file://' + str(TOP / 'tests/testing/packages/pure_python_package'))
 
     venv_update()
-    assert 'pure-python-package' in pip_freeze()
+    assert '#egg=pure_python_package' in pip_freeze()
+
+
+@pytest.mark.usefixtures('pypi_server')
+def test_not_installable_thing(tmpdir):
+    tmpdir.chdir()
+    enable_coverage()
+
+    install_coverage()
+
+    requirements('not-a-real-package-plz')
+    with pytest.raises(CalledProcessError):
+        venv_update()
+
+
+@pytest.mark.usefixtures('pypi_server', 'pypi_packages')
+def test_doesnt_use_cache_without_index_server(tmpdir):
+    tmpdir.chdir()
+    enable_coverage()
+
+    requirements('pure-python-package==0.2.1')
+    venv_update()
+
+    tmpdir.join('venv').remove()
+    install_coverage()
+
+    cmd = ('pip-command=', 'pip-faster', 'install')
+    with pytest.raises(CalledProcessError):
+        venv_update(*(cmd + ('--no-index',)))
+    # But it would succeed if we gave it an index
+    venv_update(*cmd)
 
 
 @pytest.mark.usefixtures('pypi_server_with_fallback')
@@ -131,11 +161,10 @@ def assert_timestamps(*reqs):
     # garbage, to cause a failure
     lastreq.write('-w wat')
 
-    from subprocess import CalledProcessError
     with pytest.raises(CalledProcessError) as excinfo:
         venv_update(*args)
 
-    assert excinfo.value.returncode == 2
+    assert excinfo.value.returncode == 1
     assert firstreq.mtime() > Path('venv').mtime()
 
     # blank requirements should succeed
@@ -225,7 +254,6 @@ def test_args_backward(tmpdir):
     enable_coverage()
     requirements('')
 
-    from subprocess import CalledProcessError
     with pytest.raises(CalledProcessError) as excinfo:
         venv_update('venv=', 'requirements.txt')
 
@@ -262,7 +290,7 @@ def test_wrong_wheel(tmpdir):
     ret2out, _ = venv_update('venv=', 'venv2', '-p' + other_python.interpreter, 'install=', '-vv', '-r', 'requirements.txt')
 
     assert '''
-  No wheel found locally for pinned requirement pure-python-package==0.1.0 (from -r requirements.txt (line 1))
+  No wheel found locally for pinned requirement pure_python_package==0.1.0 (from -r requirements.txt (line 1))
 ''' in uncolor(ret2out)
 
 
@@ -280,14 +308,13 @@ pep8<=1.5.7
 ''' % TOP)
     venv_update()
     assert pip_freeze() == '\n'.join((
-        'coverage==4.3.3',
+        'coverage==4.3.4',
         'coverage-enable-subprocess==1.0',
         'flake8==2.0',
         'mccabe==0.3',
         'pep8==1.5.7',
         'pyflakes==0.7.3',
         'venv-update==' + __version__,
-        'wheel==0.29.0',
         ''
     ))
 
@@ -306,14 +333,13 @@ pep8<=1.5.7
 ''' % TOP)
     venv_update()
     assert pip_freeze() == '\n'.join((
-        'coverage==4.3.3',
+        'coverage==4.3.4',
         'coverage-enable-subprocess==1.0',
         'flake8==2.2.5',
         'mccabe==0.3',
         'pep8==1.5.7',
         'pyflakes==0.8.1',
         'venv-update==' + __version__,
-        'wheel==0.29.0',
         ''
     ))
 
@@ -355,20 +381,20 @@ pure_python_package
         'bootstrap-deps=', '-r', 'requirements-bootstrap.txt',
     )
     err = strip_pip_warnings(err)
-    assert err == ''
+    assert err == (
+        'You must give at least one requirement to install '
+        '(see "pip help install")\n'
+    )
 
     out = uncolor(out)
+    assert '\n> pip install -r requirements-bootstrap.txt\n' in out
     assert (
-        '\n> pip install --find-links=file://%s/home/.cache/pip-faster/wheelhouse -r requirements-bootstrap.txt\n' % tmpdir
+        '\nSuccessfully installed pure-python-package-0.2.1 venv-update-%s' % __version__
     ) in out
-    assert (
-        '\nSuccessfully installed pip-1.5.6 pure-python-package-0.2.1 venv-update-%s' % __version__
-    ) in out
-    assert '\n  Successfully uninstalled pure-python-package\n' in out
+    assert '\n  Successfully uninstalled pure-python-package-0.2.1\n' in out
 
     expected = '\n'.join((
         'venv-update==%s' % __version__,
-        'wheel==0.29.0',
         ''
     ))
     assert pip_freeze() == expected
@@ -383,24 +409,14 @@ def test_cant_wheel_package(tmpdir):
 
         out, err = venv_update()
         err = strip_pip_warnings(err)
-        assert err == ''
+        assert err == '  Failed building wheel for cant-wheel-package\n'
 
         out = uncolor(out)
 
-        # for unknown reasons, py27 has an extra line with four spaces in this output, where py26 does not.
-        out = out.replace('\n    \n', '\n')
-        assert '''
-
-----------------------------------------
-Failed building wheel for cant-wheel-package
-Running setup.py bdist_wheel for pure-python-package
-Destination directory: %s/home/.cache/pip-faster/wheelhouse''' % tmpdir + '''
-SLOW!! no wheel found after building (couldn't be wheeled?): cant-wheel-package==0.1.0
+        assert '''\
 Installing collected packages: cant-wheel-package, pure-python-package
-  Running setup.py install for cant-wheel-package
-  Could not find .egg-info directory in install record for cant-wheel-package (from -r requirements.txt (line 1))
-Successfully installed cant-wheel-package pure-python-package
-Cleaning up...
+  Running setup.py install for cant-wheel-package ... done
+Successfully installed cant-wheel-package-0.1.0 pure-python-package-0.2.1
 ''' in out  # noqa
         assert pip_freeze().startswith('cant-wheel-package==0.1.0\n')
 
@@ -419,7 +435,6 @@ def test_has_extras(tmpdir):
                 'implicit-dependency==1',
                 'pure-python-package==0.2.1',
                 'venv-update==%s' % __version__,
-                'wheel==0.29.0',
                 ''
             ))
             assert pip_freeze() == expected

--- a/tests/functional/simple_test.py
+++ b/tests/functional/simple_test.py
@@ -8,6 +8,7 @@ from sys import version_info
 import pytest
 from py._path.local import LocalPath as Path
 
+from testing import cached_wheels
 from testing import enable_coverage
 from testing import install_coverage
 from testing import OtherPython
@@ -129,6 +130,21 @@ def test_doesnt_use_cache_without_index_server(tmpdir):
         venv_update(*(cmd + ('--no-index',)))
     # But it would succeed if we gave it an index
     venv_update(*cmd)
+
+
+@pytest.mark.usefixtures('pypi_server', 'pypi_packages')
+def test_extra_index_url_doesnt_cache(tmpdir):
+    tmpdir.chdir()
+    enable_coverage()
+    install_coverage()
+
+    requirements('pure-python-package==0.2.1')
+    venv_update(
+        'pip-command=', 'pip-faster', 'install',
+        '--extra-index-url=https://pypi.python.org/simple',
+    )
+
+    assert not tuple(cached_wheels(tmpdir))
 
 
 @pytest.mark.usefixtures('pypi_server_with_fallback')

--- a/tests/functional/validation.py
+++ b/tests/functional/validation.py
@@ -116,6 +116,7 @@ def test_update_while_active(tmpdir):
     venv_update_symlink_pwd()
     out, err = run('sh', '-c', '. venv/bin/activate && python venv_update.py venv= venv --python=venv/bin/python')
     out = uncolor(out)
+    err = strip_pip_warnings(err)
 
     assert err == ''
     assert out.startswith('''\
@@ -161,7 +162,11 @@ def test_update_invalidated_missing_activate(tmpdir):
 
         out, err = venv_update()
         err = strip_pip_warnings(err)
-        assert err == "sh: 1: .: Can't open venv/bin/activate\n"
+        assert err == (
+            "sh: 1: .: Can't open venv/bin/activate\n"
+            'You must give at least one requirement to install '
+            '(see "pip help install")\n'
+        )
         out = uncolor(out)
         assert out.startswith('''\
 > virtualenv venv
@@ -186,13 +191,16 @@ def it_gives_the_same_python_version_as_we_started_with(tmpdir):
         out, err = run('./venv/bin/python', 'venv_update.py')
 
         err = strip_pip_warnings(err)
-        assert err == ''
+        assert err == (
+            'You must give at least one requirement to install '
+            '(see "pip help install")\n'
+        )
         out = uncolor(out)
         assert out.startswith('''\
 > virtualenv venv
 Keeping valid virtualenv from previous run.
-> pip install --find-links=file://%s/home/.cache/pip-faster/wheelhouse venv-update==%s
-''' % (tmpdir, __version__))
+> pip install venv-update=={0}
+'''.format(__version__))
 
         final_version = assert_python_version(other_python.version_prefix)
         assert final_version == initial_version

--- a/tests/testing/__init__.py
+++ b/tests/testing/__init__.py
@@ -3,9 +3,11 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import os
 from re import compile as Regex
 from re import MULTILINE
 
+from pip.wheel import Wheel
 from py._path.local import LocalPath as Path
 
 TOP = Path(__file__) / '../../..'
@@ -36,11 +38,7 @@ def run(*cmd, **env):
 
 def venv_update(*args, **env):
     # we get coverage for free via the (patched) pytest-cov plugin
-    return run(
-        'venv-update',
-        *args,
-        **env
-    )
+    return run('venv-update', *args, **env)
 
 
 def venv_update_symlink_pwd():
@@ -93,6 +91,7 @@ def uncolor(text):
     # the colored_tty, uncolored_pipe tests cover this pretty well.
     from re import sub
     text = sub('\033\\[[^A-z]*[A-z]', '', text)
+    text = sub('.\b', '', text)
     return sub('[^\n\r]*\r', '', text)
 
 
@@ -136,3 +135,12 @@ class OtherPython(object):
         else:
             self.interpreter = 'python2.7'
             self.version_prefix = '2.7.'
+
+
+def cached_wheels(tmpdir):
+    for _, _, filenames in os.walk(
+            tmpdir.join('home', '.cache', 'pip-faster', 'wheelhouse').strpath,
+    ):
+        for filename in filenames:
+            assert filename.endswith('.whl'), filename
+            yield Wheel(filename)

--- a/tests/testing/packages/pure_python_package_2/setup.py
+++ b/tests/testing/packages/pure_python_package_2/setup.py
@@ -13,7 +13,7 @@ setup(
     author_email='nobody@example.com',
     py_modules=[str('pure_python_package')],
     extras_require={
-        'my_extra': ['implicit_dependency'],
+        'my-extra': ['implicit_dependency'],
     },
     entry_points={
         'console_scripts': [

--- a/tests/unit/simple_test.py
+++ b/tests/unit/simple_test.py
@@ -13,52 +13,6 @@ def test_importable():
     assert venv_update
 
 
-def test_parse_reqs(tmpdir):
-    tmpdir.chdir()
-
-    with open('setup.py', 'w') as setup:
-        setup.write('\n')
-
-    with open('reqs.txt', 'w') as reqs:
-        reqs.write('''\
-.
-
--r reqs2.txt
-# a comment here
-mccabe
-
-pep8==1.0
-
--e hg+https://bitbucket.org/bukzor/coverage.py@__main__-support#egg=aweirdname
--e git+git://github.com/bukzor/cov-core.git@master#egg=cov-core
-hg+https://bitbucket.org/logilab/pylint@58c66aa083777059a2e6b46f6a0545a2f4977097
-
-file:///my/random/project
--e file:///my/random/project2
-''')
-
-    with open('reqs2.txt', 'w') as reqs:
-        reqs.write('''\
-pep8''')
-
-    # show that ordering is preserved in the parse
-    parsed = pip_faster.pip_parse_requirements(('reqs.txt',))
-    assert [
-        (req.name, req.url)
-        for req in parsed
-    ] == [
-        (None, 'file://' + tmpdir.strpath),
-        ('pep8', None),
-        ('mccabe', None),
-        ('pep8', None),
-        ('aweirdname', 'hg+https://bitbucket.org/bukzor/coverage.py@__main__-support#egg=aweirdname'),
-        ('cov-core', 'git+git://github.com/bukzor/cov-core.git@master#egg=cov-core'),
-        (None, 'hg+https://bitbucket.org/logilab/pylint@58c66aa083777059a2e6b46f6a0545a2f4977097'),
-        (None, 'file:///my/random/project'),
-        (None, 'file:///my/random/project2'),
-    ]
-
-
 def test_pip_get_installed():
     installed = pip_faster.pip_get_installed()
     installed = pip_faster.reqnames(installed)
@@ -143,34 +97,21 @@ def test_shellescape_relpath_longer(tmpdir):
 
 
 @pytest.mark.parametrize('req,expected', [
-    (
-        'foo',
-        False,
-    ), (
-        'foo==1',
-        True,
-    ), (
-        'bar<3,==2,>1',
-        True,
-    ), (
-        'quux<3,!=2,>1',
-        False,
-    ), (
-        'wat==2,!=2',
-        True,
-    ), (
-        'wat-more==2,==3',
-        True,
-    )
+    ('foo', False),
+    ('foo==1', True),
+    ('bar<3,==2,>1', True),
+    ('quux<3,!=2,>1', False),
+    ('wat==2,!=2', True),
+    ('wat-more==2,==3', True),
 ])
-def test_req_is_pinned(req, expected):
+def test_is_req_pinned(req, expected):
     from pkg_resources import Requirement
     req = Requirement.parse(req)
-    assert pip_faster.req_is_pinned(req) is expected
+    assert pip_faster.is_req_pinned(req) is expected
 
 
-def test_req_is_pinned_null():
-    assert pip_faster.req_is_pinned(None) is False
+def test_is_req_pinned_null():
+    assert pip_faster.is_req_pinned(None) is False
 
 
 def test_wait_for_all_subprocesses(monkeypatch):

--- a/venv_update.py
+++ b/venv_update.py
@@ -367,21 +367,6 @@ def user_cache_dir():
     return getenv('XDG_CACHE_HOME', expanduser('~/.cache'))
 
 
-class CacheOpts(object):
-
-    def __init__(self):
-        # We put the cache in the directory that pip already uses.
-        # This has better security characteristics than a machine-wide cache, and is a
-        #   pattern people can use for open-source projects
-        self.pipdir = user_cache_dir() + '/pip-faster'
-        # We could combine these caches to one directory, but pip would search everything twice, going slower.
-        self.wheelhouse = self.pipdir + '/wheelhouse'
-
-        self.pip_options = (
-            '--find-links=file://' + self.wheelhouse,
-        )
-
-
 def venv_update(
         venv=DEFAULT_OPTION_VALUES['venv='],
         install=DEFAULT_OPTION_VALUES['install='],
@@ -429,9 +414,7 @@ def pip_faster(venv_path, pip_command, install, bootstrap_deps):
     # we always have to run the bootstrap, because the presense of an
     # executable doesn't imply the right version. pip is able to validate the
     # version in the fastpath case quickly anyway.
-    bootstrap_command = ('pip', 'install') + CacheOpts().pip_options
-    bootstrap_command += bootstrap_deps
-    run(bootstrap_command)
+    run(('pip', 'install') + bootstrap_deps)
 
     run(pip_command + install)
 


### PR DESCRIPTION
- Replaces #166 
- Relates to #168 (possibly solves, I'll check in a followup)
- Resolves #103
- Resolves #27

A good bunch of our machinery goes away due to pip implementing wheeling-before-install \o/.  As such we may find that bugs like #155 magically fixed