### PR TITLE
Simplify installation instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,7 +8,7 @@
 1. `git tag v{{version}}`
 1. `git push origin master --tags`
 1.  upload to pypi
-    1. if you need to set up pypy auth, `python setup.py register` and follow the prompts
+    1. if you need to set up pypi auth, `python setup.py register` and follow the prompts
     1. `python setup.py sdist bdist_wheel`
     1. `twine upload --skip-existing dist/*`
 1. `fetch-python-package venv-update` -- upload to pypi.yelpcorp

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,15 +1,14 @@
 **NOTE:** This guide is only useful for the owners of the venv-update project.
 
-1. `git checkout upstream/master -b {{branch}}`
+1. start on the latest master
 1. bump `venv_update.py`
+1. bump the URL in the `docs/source/index.rst` curl command with the new
+   version tag
 1. `git commit -m "this is {{version}}"`
-1. Create a pull request
-1. Wait for review / merge
-1. go to https://github.com/Yelp/pip-faster/releases and add a tag
-1. `git fetch yelp --tags`
-1. `git checkout v1.1.0`   --  for example
+1. `git tag v{{version}}`
+1. `git push origin master --tags`
 1.  upload to pypi
     1. if you need to set up pypy auth, `python setup.py register` and follow the prompts
     1. `python setup.py sdist bdist_wheel`
     1. `twine upload --skip-existing dist/*`
-1. `fetch_python_package pip-faster` -- upload to pypi.yelpcorp
+1. `fetch-python-package venv-update` -- upload to pypi.yelpcorp

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -115,10 +115,8 @@ Python library.
 
 .. parsed-literal::
 
- curl `<https://yelp.github.io/venv-update/install.txt>`_ | bash
- git add bin/venv-update
-
-The paranoid should `read the script <https://yelp.github.io/venv-update/install.txt>`_.
+ curl -o venv-update `<https://raw.githubusercontent.com/Yelp/venv-update/v2.1.1/venv_update.py>`_
+ chmod +x venv-update
 
 
 Usage


### PR DESCRIPTION
Fixes #164, #175, #176, and obsoletes #190.

I think the docs build might be broken still, so we may need to figure out how to fix that after merging this.

On another note, I wish we'd just put the docs back in the README, I don't think venv-update is so complicated that it needs external documentation. Having to click onto external docs also decreases the number of people who will actually read them.

Also... I can't even find the `install.txt` script? Where does that come from?