### PR TITLE
Make compatible with pip 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 /dist
 /tmp*/
 /venv/
-/.cache
+/.pytest_cache
 
 # ignored anywhere
 *.egg-info/

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ all: lint test
 
 .PHONY: lint
 lint: venv
-	. venv/bin/activate && pre-commit run --all-files
+	venv/bin/pre-commit install -f --install-hooks
+	venv/bin/pre-commit run --all-files
 
 .PHONY: test tests
 test tests: venv

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export PYTHON?=python2.7
+export PYTHON?=python3.6
 export REQUIREMENTS?=requirements.txt
 
 .PHONY: all

--- a/pip_faster.py
+++ b/pip_faster.py
@@ -384,11 +384,10 @@ class FasterInstallCommand(InstallCommand):
             )
 
         required = requirement_set.requirements.values()
-        successfully_installed = requirement_set.successfully_downloaded
 
         # With extra_index_urls we don't know where the wheel is from
         if not options.extra_index_urls:
-            cache_installed_wheels(options.index_url, successfully_installed)
+            cache_installed_wheels(options.index_url, requirement_set.successfully_downloaded)
 
         if not options.ignore_dependencies:
             # transitive requirements, previously installed, are also required
@@ -401,7 +400,6 @@ class FasterInstallCommand(InstallCommand):
             extraneous = (
                 reqnames(previously_installed) -
                 reqnames(required) -
-                reqnames(successfully_installed) -
                 # the stage1 bootstrap packages
                 reqnames(trace_requirements([InstallRequirement.from_line('venv-update')])) -
                 # See #186

--- a/requirements.d/import_tests.txt
+++ b/requirements.d/import_tests.txt
@@ -4,6 +4,6 @@
 
 pytest
 ephemeral-port-reserve
-pip>=8.1,<=9.999
+pip>=10.0.0
 wheel
 six

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ def main():
         py_modules=['venv_update', 'pip_faster'],
         packages=find_packages(exclude=('tests*',)),
         install_requires=[
-            'pip>=8.1.0,<=9.999',
+            'pip>=10.0.0',
             'wheel>0.25.0',  # 0.25.0 causes get_tag AssertionError in python3
             'setuptools>=0.8.0',  # 0.7 causes "'sys_platform' not defined" when installing wheel >0.25
         ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,9 @@ def fixed_environment_variables():
     os.environ['PIP_INDEX_URL'] = '(total garbage)'
     os.environ['PYTHONWARNINGS'] = 'ignore:Support for Python 3.0-3.2 has been dropped.:UserWarning'
 
+    # Fixes argparse help tests.
+    os.environ['COLUMNS'] = '1000'
+
     # normalize $PATH
     from sys import executable
     from os import defpath

--- a/tests/functional/conflict_test.py
+++ b/tests/functional/conflict_test.py
@@ -42,6 +42,9 @@ conflicting_package
     err = T.strip_coverage_warnings(err)
     err = T.strip_pip_warnings(err)
     assert err == (
+        "conflicting-package 1 has requirement many-versions-package<2, but you'll "
+        "have many-versions-package 3 which is incompatible.\n"
+        # TODO: do we still need to append our own error?
         'Error: version conflict: many-versions-package 3 (venv/{}) '
         '<-> many-versions-package<2 '
         '(from conflicting_package->-r requirements.txt (line 3))\n'.format(
@@ -79,6 +82,10 @@ pure_python_package==0.1.0
     err = T.strip_coverage_warnings(err)
     err = T.strip_pip_warnings(err)
     assert err == (
+        'dependant-package 1 requires implicit-dependency, which is not installed.\n'
+        "dependant-package 1 has requirement pure-python-package>=0.2.1, but you'll have pure-python-package 0.1.0 which is incompatible.\n"
+        "conflicting-package 1 has requirement many-versions-package<2, but you'll have many-versions-package 3 which is incompatible.\n"
+        # TODO: do we still need to append our own error?
         'Error: version conflict: pure-python-package 0.1.0 '
         '(venv/{lib}) <-> pure-python-package>=0.2.1 '
         '(from dependant_package->-r requirements.txt (line 2))\n'

--- a/tests/functional/conflict_test.py
+++ b/tests/functional/conflict_test.py
@@ -81,17 +81,22 @@ pure_python_package==0.1.0
 
     err = T.strip_coverage_warnings(err)
     err = T.strip_pip_warnings(err)
-    assert err == (
-        'dependant-package 1 requires implicit-dependency, which is not installed.\n'
-        "dependant-package 1 has requirement pure-python-package>=0.2.1, but you'll have pure-python-package 0.1.0 which is incompatible.\n"  # noqa
-        "conflicting-package 1 has requirement many-versions-package<2, but you'll have many-versions-package 3 which is incompatible.\n"  # noqa
-        # TODO: do we still need to append our own error?
+
+    err = err.splitlines()
+    # pip outputs conflict lines in a non-consistent order
+    assert set(err[:3]) == {
+        'dependant-package 1 requires implicit-dependency, which is not installed.',
+        "dependant-package 1 has requirement pure-python-package>=0.2.1, but you'll have pure-python-package 0.1.0 which is incompatible.",  # noqa
+        "conflicting-package 1 has requirement many-versions-package<2, but you'll have many-versions-package 3 which is incompatible.",  # noqa
+    }
+    # TODO: do we still need to append our own error?
+    assert '\n'.join(err[3:]) == (
         'Error: version conflict: pure-python-package 0.1.0 '
         '(venv/{lib}) <-> pure-python-package>=0.2.1 '
         '(from dependant_package->-r requirements.txt (line 2))\n'
         'Error: version conflict: many-versions-package 3 '
         '(venv/{lib}) <-> many-versions-package<2 '
-        '(from conflicting_package->-r requirements.txt (line 3))\n'.format(
+        '(from conflicting_package->-r requirements.txt (line 3))'.format(
             lib=PYTHON_LIB,
         )
     )

--- a/tests/functional/conflict_test.py
+++ b/tests/functional/conflict_test.py
@@ -43,7 +43,7 @@ conflicting_package
     err = T.strip_pip_warnings(err)
     assert err == (
         "conflicting-package 1 has requirement many-versions-package<2, but you'll "
-        "have many-versions-package 3 which is incompatible.\n"
+        'have many-versions-package 3 which is incompatible.\n'
         # TODO: do we still need to append our own error?
         'Error: version conflict: many-versions-package 3 (venv/{}) '
         '<-> many-versions-package<2 '
@@ -83,8 +83,8 @@ pure_python_package==0.1.0
     err = T.strip_pip_warnings(err)
     assert err == (
         'dependant-package 1 requires implicit-dependency, which is not installed.\n'
-        "dependant-package 1 has requirement pure-python-package>=0.2.1, but you'll have pure-python-package 0.1.0 which is incompatible.\n"
-        "conflicting-package 1 has requirement many-versions-package<2, but you'll have many-versions-package 3 which is incompatible.\n"
+        "dependant-package 1 has requirement pure-python-package>=0.2.1, but you'll have pure-python-package 0.1.0 which is incompatible.\n"  # noqa
+        "conflicting-package 1 has requirement many-versions-package<2, but you'll have many-versions-package 3 which is incompatible.\n"  # noqa
         # TODO: do we still need to append our own error?
         'Error: version conflict: pure-python-package 0.1.0 '
         '(venv/{lib}) <-> pure-python-package>=0.2.1 '

--- a/tests/functional/pip_faster.py
+++ b/tests/functional/pip_faster.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import pytest
+from subprocess import CalledProcessError
 
 from testing import cached_wheels
 from testing import install_coverage
@@ -204,9 +205,10 @@ def it_gives_proper_error_without_requirements(tmpdir):
     pip = venv.join('bin/pip').strpath
     run(pip, 'install', 'venv-update==' + __version__)
 
-    _, err = run(str(venv.join('bin/pip-faster')), 'install')
-    err = strip_pip_warnings(err)
-    assert err.startswith('You must give at least one requirement to install')
+    with pytest.raises(CalledProcessError) as exc_info:
+        run(str(venv.join('bin/pip-faster')), 'install')
+    _, err = exc_info.value.result
+    assert err.startswith('ERROR: You must give at least one requirement to install')
 
 
 @pytest.mark.usefixtures('pypi_server')

--- a/tests/functional/pip_faster.py
+++ b/tests/functional/pip_faster.py
@@ -2,8 +2,9 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import pytest
 from subprocess import CalledProcessError
+
+import pytest
 
 from testing import cached_wheels
 from testing import install_coverage

--- a/tests/functional/simple_test.py
+++ b/tests/functional/simple_test.py
@@ -67,7 +67,7 @@ def test_arguments_version(tmpdir):
     out = uncolor(out)
     lines = out.splitlines()
     # 13:py27 14:py35 15:pypy
-    assert len(lines) == 8, repr(lines)
+    assert len(lines) == 9, repr(lines)
     assert lines[-2] == '> virtualenv --version', repr(lines)
 
 
@@ -409,10 +409,8 @@ pure_python_package
         'bootstrap-deps=', '-r', 'requirements-bootstrap.txt',
     )
     err = strip_pip_warnings(err)
-    assert err == (
-        'You must give at least one requirement to install '
-        '(see "pip help install")\n'
-    )
+    # pip>=10 doesn't complain about installing an empty requirements file.
+    assert err == ''
 
     out = uncolor(out)
     assert '\n> pip install -r requirements-bootstrap.txt\n' in out

--- a/tests/functional/validation.py
+++ b/tests/functional/validation.py
@@ -162,11 +162,7 @@ def test_update_invalidated_missing_activate(tmpdir):
 
         out, err = venv_update()
         err = strip_pip_warnings(err)
-        assert err == (
-            "sh: 1: .: Can't open venv/bin/activate\n"
-            'You must give at least one requirement to install '
-            '(see "pip help install")\n'
-        )
+        assert err == "sh: 1: .: Can't open venv/bin/activate\n"
         out = uncolor(out)
         assert out.startswith('''\
 > virtualenv venv
@@ -191,10 +187,7 @@ def it_gives_the_same_python_version_as_we_started_with(tmpdir):
         out, err = run('./venv/bin/python', 'venv_update.py')
 
         err = strip_pip_warnings(err)
-        assert err == (
-            'You must give at least one requirement to install '
-            '(see "pip help install")\n'
-        )
+        assert err == ''
         out = uncolor(out)
         assert out.startswith('''\
 > virtualenv venv

--- a/tests/regression/pip_faster.py
+++ b/tests/regression/pip_faster.py
@@ -118,6 +118,7 @@ def test_install_whl_over_http(pypi_server):
     assert err == ''
     out = uncolor(out)
     assert out == '''\
+Looking in indexes: {server}/simple
 Collecting wheeled-package==0.2.0 from {server}/packages/wheeled_package-0.2.0-py2.py3-none-any.whl
   Downloading {server}/packages/wheeled_package-0.2.0-py2.py3-none-any.whl
 Installing collected packages: wheeled-package

--- a/tests/testing/__init__.py
+++ b/tests/testing/__init__.py
@@ -7,7 +7,7 @@ import os
 from re import compile as Regex
 from re import MULTILINE
 
-from pip.wheel import Wheel
+from pip._internal.wheel import Wheel
 from py._path.local import LocalPath as Path
 
 TOP = Path(__file__) / '../../..'


### PR DESCRIPTION
Fixes #203

Mostly just updating the imports and changing some assertions about stdout/stderr to match newer pip's error messages.

Everything is passing in Travis now including latest-pip.