### PR TITLE
Fix build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ matrix:
           python: pypy-5.4.1
         - env: TOXENV=py27
           python: 2.7
-        - env: TOXENV=py35
-          python: 3.5
         - env: TOXENV=latest-pip
           python: 3.6
 

--- a/requirements.d/import_tests.txt
+++ b/requirements.d/import_tests.txt
@@ -4,6 +4,6 @@
 
 pytest>=3.6.0
 ephemeral-port-reserve
-pip>=10.0.0
+pip>=10.0.0,<=18.0
 wheel
 six

--- a/requirements.d/import_tests.txt
+++ b/requirements.d/import_tests.txt
@@ -2,7 +2,7 @@
 # this is used by the lint environment.
 -r coverage.txt
 
-pytest
+pytest>=3.6.0
 ephemeral-port-reserve
 pip>=10.0.0
 wheel

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ def main():
         py_modules=['venv_update', 'pip_faster'],
         packages=find_packages(exclude=('tests*',)),
         install_requires=[
-            'pip>=10.0.0',
+            'pip>=10.0.0,<=18.0',
             'wheel>0.25.0',  # 0.25.0 causes get_tag AssertionError in python3
             'setuptools>=0.8.0',  # 0.7 causes "'sys_platform' not defined" when installing wheel >0.25
         ],

--- a/tests/functional/conflict_test.py
+++ b/tests/functional/conflict_test.py
@@ -85,15 +85,14 @@ pure_python_package==0.1.0
     err = err.splitlines()
     # pip outputs conflict lines in a non-consistent order
     assert set(err[:3]) == {
-        'dependant-package 1 requires implicit-dependency, which is not installed.',
-        "dependant-package 1 has requirement pure-python-package>=0.2.1, but you'll have pure-python-package 0.1.0 which is incompatible.",  # noqa
         "conflicting-package 1 has requirement many-versions-package<2, but you'll have many-versions-package 3 which is incompatible.",  # noqa
+        "dependant-package 1 has requirement pure-python-package>=0.2.1, but you'll have pure-python-package 0.1.0 which is incompatible.",  # noqa
+        'Error: version conflict: pure-python-package 0.1.0 (venv/{lib}) <-> pure-python-package>=0.2.1 (from dependant_package->-r requirements.txt (line 2))'.format(  # noqa
+            lib=PYTHON_LIB,
+        ),
     }
     # TODO: do we still need to append our own error?
     assert '\n'.join(err[3:]) == (
-        'Error: version conflict: pure-python-package 0.1.0 '
-        '(venv/{lib}) <-> pure-python-package>=0.2.1 '
-        '(from dependant_package->-r requirements.txt (line 2))\n'
         'Error: version conflict: many-versions-package 3 '
         '(venv/{lib}) <-> many-versions-package<2 '
         '(from conflicting_package->-r requirements.txt (line 3))'.format(

--- a/tests/functional/get_installed_test.py
+++ b/tests/functional/get_installed_test.py
@@ -56,9 +56,7 @@ def test_pip_get_installed(tmpdir):
         'pluggy', 'py', 'pytest', 'pytest-cov', 'six',
     ]
     if PY2:  # :pragma:nocover:
-        expected.extend(['funcsigs', 'scandir'])
-    if sys.version_info < (3, 6):
-        expected.append('pathlib2')
+        expected.extend(['funcsigs', 'pathlib2', 'scandir'])
 
     assert get_installed() == sorted(expected)
 

--- a/tests/functional/get_installed_test.py
+++ b/tests/functional/get_installed_test.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import sys
-
 import pytest
 
 from pip_faster import PY2

--- a/tests/functional/get_installed_test.py
+++ b/tests/functional/get_installed_test.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import sys
+
 import pytest
 
 from pip_faster import PY2
@@ -48,13 +50,17 @@ def test_pip_get_installed(tmpdir):
         'git+git://github.com/bukzor/cov-core.git@master#egg=cov-core',
         '-e', 'git+git://github.com/bukzor/pytest-cov.git@master#egg=pytest-cov',
     )
+
     expected = [
-        'attrs', 'cov-core', 'coverage', 'more-itertools', 'pluggy', 'py',
-        'pytest', 'pytest-cov', 'six',
+        'atomicwrites', 'attrs', 'cov-core', 'coverage', 'more-itertools',
+        'pluggy', 'py', 'pytest', 'pytest-cov', 'six',
     ]
     if PY2:  # :pragma:nocover:
-        expected.insert(3, 'funcsigs')
-    assert get_installed() == expected
+        expected.extend(['funcsigs', 'scandir'])
+    if sys.version_info < (3, 6):
+        expected.append('pathlib2')
+
+    assert get_installed() == sorted(expected)
 
     run('myvenv/bin/pip', 'uninstall', '--yes', *expected)
     assert get_installed() == []

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # These should match the travis env list
-envlist = py27,py35,py36,pypy,lint
+envlist = py27,py36,pypy,lint
 skipsdist=True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ commands =
 
 [testenv:latest-pip]
 commands =
+    sed -i 's/,<=18.0//g' {toxinidir}/setup.py {toxinidir}/requirements.d/import_tests.txt
     pip install git+git://github.com/pypa/pip
     {[testenv]commands}
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,9 +25,7 @@ commands =
     {toxinidir}/test {posargs}
 
 [testenv:latest-pip]
-whitelist_externals = sed
 commands =
-    sed -i 's/,<=9.999//g' {toxinidir}/setup.py {toxinidir}/requirements.d/import_tests.txt
     pip install git+git://github.com/pypa/pip
     {[testenv]commands}
 


### PR DESCRIPTION
The objective of this PR is to make travis happy again 😄 

Notable changes:
 * the new pip version (18.0) has changed a bit the way errors are reported, so I needed to update `test_multiple_issues`
 * pytest, starting from version 3.6.0 has changed a bit its dependencies this was causing `test_pip_get_installed` to fail
 * performed a minor tox.ini cleanup as `latest-pip` testenv was doing some "sed magic" that from venv-update 3.1.0 is a no-op
