### PR TITLE
Add VENV_UPDATE_CACHE_DIR to override cache dir when desired

### DIFF
--- a/tests/unit/simple_test.py
+++ b/tests/unit/simple_test.py
@@ -166,6 +166,9 @@ def test_user_cache_dir():
     environ['XDG_CACHE_HOME'] = '/quux/bar'
     assert venv_update.user_cache_dir() == '/quux/bar'
 
+    environ['VENV_UPDATE_CACHE_DIR'] = '/bar/foo/venv-update-specific-cache'
+    assert venv_update.user_cache_dir() == '/bar/foo/venv-update-specific-cache'
+
 
 def test_get_python_version():
     import sys

--- a/venv_update.py
+++ b/venv_update.py
@@ -381,7 +381,7 @@ def user_cache_dir():
     # stolen from pip.utils.appdirs.user_cache_dir
     from os import getenv
     from os.path import expanduser
-    return getenv('XDG_CACHE_HOME', expanduser('~/.cache'))
+    return getenv('VENV_UPDATE_CACHE_DIR', getenv('XDG_CACHE_HOME', expanduser('~/.cache')))
 
 
 def venv_update(


### PR DESCRIPTION
# Problem
Jira context: CID-1596

We've been having some issues with builds using venv-update,  where parallel invocations of venv-update step on each other's toes and result in errors like ` Text file busy: '/ephemeral/xdg_cache/venv-update/3.2.4/venv/bin/python2'`
or `/ephemeral/xdg_cache/venv-update/3.2.4/venv/bin/python: No module named pip`. This issue is very difficult to reproduce locally. 

# Solution

In an effort to dig further into the issue, I've added support for `VENV_UPDATE_CACHE_DIR` to be set, to override the cache directory to a specific folder. This should help with identifying where, if anywhere, a race condition exists.  I did this instead of just overriding XDG_CACHE_DIR because many other tools also use that directory, and I want to try this out in isolation. 

# Testing

I added a test to ensure that the environment variable is preferred when set. `make test` passes locally. 

